### PR TITLE
make synthetics fail for at least 3 minutes

### DIFF
--- a/api_synthetic/variables.tf
+++ b/api_synthetic/variables.tf
@@ -27,7 +27,7 @@ variable "options" {
 
   default = {
     tick_every           = 60
-    min_failure_duration = 3
+    min_failure_duration = 180
     min_location_failed  = 1
   }
 }


### PR DESCRIPTION
Synthetics should alert only after 3 minutes, or 180 seconds (meaning 3 consecutive failures).