### PR TITLE
Remove incorrect warning threshold

### DIFF
--- a/apm_monitors/variables.tf
+++ b/apm_monitors/variables.tf
@@ -40,7 +40,6 @@ variable "high_p90_latency_thresholds" {
 
   default = {
     critical = 1
-    warning  = 0
   }
 }
 


### PR DESCRIPTION
Setting warning to '0' will cause terraformed-managed monitors to always report they are in warning state.